### PR TITLE
Last Name Ascending Group Generation

### DIFF
--- a/public/assets/js/teacher.js
+++ b/public/assets/js/teacher.js
@@ -261,10 +261,12 @@ document.addEventListener('DOMContentLoaded', function() {
 
   /* Determines class size based on the current class selected +
    * disables submit button for number of groups if a class is
-   * not selected */
+   * not selected
+   * Updates class member id list and last name list */
   $("#classes").change(function() {
     classSize = 0;
     classMemberIDList = [];
+    lastNames = [];
     currentClass = document.getElementById('classes').value;
     var teacherClassesRef = db.ref("users/" + uid + "/classes");
     teacherClassesRef.orderByKey().on('child_added', function(snapshot) { // for each teacher class
@@ -277,6 +279,10 @@ document.addEventListener('DOMContentLoaded', function() {
             classMemberSnap.forEach(function(classMember) {
               classSize++;
               classMemberIDList.push(classMember.key);
+              var lastNameRef = db.ref("users/" + classMember.key + "/lastName");
+              lastNameRef.on('value', function(lastNameSnap) {
+                lastNames.push(lastNameSnap.val());
+              });
             });
           });
         }
@@ -296,7 +302,6 @@ document.addEventListener('DOMContentLoaded', function() {
     event.preventDefault(); // prevents page refresh on submit
     // organize class member id list by last name for grouping
     var sorted = classMemberIDList.sort(compareByLastName);
-    console.log(sorted);
     var numGroups = $('#numGroupsTextBox').val();
     if (Number.isInteger(Number(numGroups)) && (numGroups > 0)) { // make sure proper text field input
       if (classSize < numGroups) {
@@ -356,9 +361,10 @@ document.addEventListener('DOMContentLoaded', function() {
       "teacher" : uid
     }).key;
     // iterate over groupNumber students starting from classMemberIndex
-    for (var i = 0; i < groupSize; i++) {
+    for (var i = classMemberIndex; i < (classMemberIndex + groupSize); i++) {
+      console.log(groupSize + ": " + classMemberIDList[i]);
       groupsRef.child(groupsKey + "/members").update({
-        [classMemberIDList[classMemberIndex]] : true
+        [classMemberIDList[i]] : true
       });
       // iterate over students in this group and add under their userid
       var studentGroupsRef = db.ref("users/" + classMemberIDList[classMemberIndex] + "/groups").update({

--- a/public/assets/js/teacher.js
+++ b/public/assets/js/teacher.js
@@ -158,7 +158,7 @@ document.addEventListener('DOMContentLoaded', function() {
         cell2.innerHTML = lastSnap.val();
       });
       cell3.innerHTML = snapshot.key;
-      cell3.style.visibility = "hidden";
+      cell3.style.display = "none";
       rowNumber++;
     });
     
@@ -202,7 +202,6 @@ document.addEventListener('DOMContentLoaded', function() {
     classRef.orderByKey().on('child_added', function(snapshot) {
       var rowNumber = 1;
 
-
       var firstNameRef = db.ref("users/" + snapshot.key + "/firstName");
       var lastNameRef = db.ref("users/" + snapshot.key + "/lastName");
 
@@ -218,7 +217,7 @@ document.addEventListener('DOMContentLoaded', function() {
         cell2.innerHTML = lastSnap.val();
       });
       cell3.innerHTML = snapshot.key;
-      cell3.style.visibility = "hidden";
+      cell3.style.display = "none";
       rowNumber++;
     });
   }
@@ -252,7 +251,7 @@ document.addEventListener('DOMContentLoaded', function() {
         lastNames.push(lastNameSnap.val());
       });
       cell3.innerHTML = snapshot.key;
-      cell3.style.visibility = "hidden";
+      cell3.style.display = "none";
       rowNumber++;
     });
 

--- a/public/assets/js/teacher.js
+++ b/public/assets/js/teacher.js
@@ -269,7 +269,7 @@ document.addEventListener('DOMContentLoaded', function() {
     teacherClassesRef.orderByKey().on('child_added', function(snapshot) { // for each teacher class
       var classRef = db.ref("classes/" + snapshot.key); // ref for teacher class
       classRef.on('value', function(classSnap) {
-        if (classSnap.val().className == currentClass) { // check for matching class by name
+        if (classSnap.key == currentClass) { // check for matching class by id
           var teacherClassesRef = db.ref("users/" + uid + "/classes");
           var classMembersRef = db.ref("classes/" + snapshot.key + "/classMembers");
           classMembersRef.on('value', function(classMemberSnap) {
@@ -280,6 +280,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
       });
     });
+    console.log("class size: " + classSize);
     var numGroupsSubmit = document.getElementById('numGroups');
     if ($(this).val() == 'Initial') {
       numGroupsSubmit.disabled = true;


### PR DESCRIPTION
I changed one thing that was weird from Chase's PR that I previously merged in which had made it look like there was an extra blank column in the tables.

Other than that, when teachers attempt to generate groups of students, this will determine how many groups + how many students per group based on the number of groups the teacher wants, make that number of groups and fill them with the right number of students based on ascending last name, and add them to all the right spots in the database all after clicking submit. An alert will inform them how many groups of what size were generated so that they know the groups are already available for viewing/use.

The students will be in the proper groups based on ascending last name, but when you go to look at the groups from the drop down on the page, the order will not be ascending by last name because of how adding to the table reads from the database.